### PR TITLE
Fix broken assertions, etrade crash, unsorted year iteration

### DIFF
--- a/pit38/domain/stock/profit/per_stock_calculator.py
+++ b/pit38/domain/stock/profit/per_stock_calculator.py
@@ -42,7 +42,7 @@ class PerStockProfitCalculator:
 
     def _get_company_name(self, transaction: List[Transaction]) -> str:
         # check all transactions are from the same company
-        assert (t.asset.asset_name == transaction[0].asset.asset_name for t in transaction), \
+        assert all(t.asset.asset_name == transaction[0].asset.asset_name for t in transaction), \
             "All transactions should be from the same company"
         return transaction[0].asset.asset_name
 

--- a/pit38/domain/stock/profit/stock_split_handler.py
+++ b/pit38/domain/stock/profit/stock_split_handler.py
@@ -56,9 +56,9 @@ class StockSplitHandler:
 
     @classmethod
     def _assert_the_same_company(cls, transactions: List[Transaction], stock_splits: List[StockSplit]):
-        assert (t.asset.asset_name == transactions[0].asset.asset_name for t in transactions), \
+        assert all(t.asset.asset_name == transactions[0].asset.asset_name for t in transactions), \
             "All transactions should be from the same company"
-        assert (split.stock == stock_splits[0].stock for split in stock_splits), \
+        assert all(split.stock == stock_splits[0].stock for split in stock_splits), \
             "All stock splits should be for the same stock"
         assert transactions[0].asset.asset_name == stock_splits[0].stock, \
             "All operations should be from the same company"

--- a/pit38/domain/tax_service/tax_calculator.py
+++ b/pit38/domain/tax_service/tax_calculator.py
@@ -48,9 +48,9 @@ class TaxCalculator:
 
         return accumulated_loss
 
-    def _years_before(self, tax_year: int, years: set[int]) -> set[int]:
-        return {
+    def _years_before(self, tax_year: int, years: set[int]) -> list[int]:
+        return sorted(
             year
             for year in years
             if year < tax_year
-        }
+        )

--- a/pit38/plugins/stock/etrade/csv.py
+++ b/pit38/plugins/stock/etrade/csv.py
@@ -3,13 +3,14 @@ from typing import Dict, List, Tuple
 from loguru import logger
 import pendulum
 
+from pit38.domain.currency_exchange_service.currencies import FiatValue
 from pit38.domain.transactions.action import Action
 from pit38.domain.transactions.asset import AssetValue
 from pit38.domain.transactions.transaction import Transaction
 from pit38.plugins.stock.etrade.row_parser import FiatValueParser
 
 
-class CsvService:
+class EtradeCsvReader:
     @classmethod
     def read(cls, file_path: str) -> List[Transaction]:
         transactions = []
@@ -59,8 +60,10 @@ class CsvService:
         stock_name = row['Symbol']
         return AssetValue(quantity, stock_name)
     
-    def _buy_cost(row: Dict) -> float:
+    @classmethod
+    def _buy_cost(cls, row: Dict) -> FiatValue:
         return FiatValueParser.parse(row["Acquisition Cost"])
-    
-    def _sell_cost(row: Dict) -> float:
+
+    @classmethod
+    def _sell_cost(cls, row: Dict) -> FiatValue:
         return FiatValueParser.parse(row["Total Proceeds"]) 


### PR DESCRIPTION
## Summary

Fixes 4 bugs found during architecture review:

- **`assert (generator)` never fails** — generator expression is always truthy. Changed to `assert all(...)` in `per_stock_calculator.py` and `stock_split_handler.py`
- **`pit38 import etrade` crashes with ImportError** — class was named `CsvService` but imported as `EtradeCsvReader`. Renamed to match.
- **Missing `@classmethod`** on `_buy_cost` / `_sell_cost` in E*Trade parser — worked by accident. Added decorators and fixed return type hints (`float` → `FiatValue`).
- **`_years_before()` returns unordered `set`** — loss accumulation depends on chronological order. Changed to `sorted()` list.

## Test plan

- [x] `pytest tests/` — 55/55 pass
- [x] `pit38 import etrade --help` — no ImportError


🤖 Generated with [Claude Code](https://claude.com/claude-code)