### PR TITLE
Fix partial sell exchange rate bug, add missing tests

### DIFF
--- a/pit38/domain/stock/profit/per_stock_calculator.py
+++ b/pit38/domain/stock/profit/per_stock_calculator.py
@@ -64,7 +64,7 @@ class PerStockProfitCalculator:
             else:
                 ratio_of_oldest_buy_to_include = stock_amount_to_account / oldest_buy_stock_amount
                 cost += self.exchanger.exchange(
-                    transaction.date, oldest_buy.fiat_value) * ratio_of_oldest_buy_to_include
+                    oldest_buy.date, oldest_buy.fiat_value) * ratio_of_oldest_buy_to_include
                 stock_amount_to_account = 0
                 new_head = buy_queue.head() * (1 - ratio_of_oldest_buy_to_include)
                 buy_queue.replace_head(new_head)

--- a/tests/test_crypto_profit_calculator.py
+++ b/tests/test_crypto_profit_calculator.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from pit38.domain.crypto.profit_calculator import YearlyProfitCalculator
 from pit38.domain.tax_service.profit_per_year import ProfitPerYear
-from tests.utils import buy, sell, btc, usd, StubExchanger, zl
+from tests.utils import buy, sell, btc, eth, usd, StubExchanger, zl
 
 
 class TestYearlyProfitCalculator(TestCase):
@@ -30,3 +30,40 @@ class TestYearlyProfitCalculator(TestCase):
         )
 
         self.assertEqual(profit_per_year, expected_profit_per_year)
+
+    def test_buy_one_year_sell_next(self):
+        transactions = [
+            buy(btc(1), usd(100), "2020-01-01"),
+            sell(btc(1), usd(300), "2021-06-01"),
+        ]
+        calculator = YearlyProfitCalculator(StubExchanger())
+        profit = calculator.profit_per_year(transactions)
+
+        self.assertEqual(profit.get_cost(2020), zl(400))
+        self.assertEqual(profit.get_income(2020), zl(0))
+        self.assertEqual(profit.get_cost(2021), zl(0))
+        self.assertEqual(profit.get_income(2021), zl(1200))
+
+    def test_buy_without_sell(self):
+        transactions = [
+            buy(btc(1), usd(100), "2020-01-01"),
+            buy(btc(2), usd(500), "2020-06-01"),
+        ]
+        calculator = YearlyProfitCalculator(StubExchanger())
+        profit = calculator.profit_per_year(transactions)
+
+        self.assertEqual(profit.get_cost(2020), zl(2400))
+        self.assertEqual(profit.get_income(2020), zl(0))
+
+    def test_multiple_cryptocurrencies(self):
+        transactions = [
+            buy(btc(1), usd(100), "2020-01-01"),
+            buy(eth(10), usd(200), "2020-01-02"),
+            sell(btc(1), usd(300), "2020-06-01"),
+            sell(eth(10), usd(500), "2020-06-02"),
+        ]
+        calculator = YearlyProfitCalculator(StubExchanger())
+        profit = calculator.profit_per_year(transactions)
+
+        self.assertEqual(profit.get_cost(2020), zl(1200))
+        self.assertEqual(profit.get_income(2020), zl(3200))

--- a/tests/test_exchanger.py
+++ b/tests/test_exchanger.py
@@ -35,3 +35,16 @@ class TestExchanger(TestCase):
         exchanger = Exchanger(ExchangeRateProviderStub(), Calendar())
         amount_in_pln = exchanger.exchange(datetime("2022-01-04"), zl(100))
         self.assertEqual(amount_in_pln, zl(100))
+
+    def test_get_day_one_skips_independence_day(self):
+        exchanger = Exchanger(None, Calendar())
+        # Nov 11 is Independence Day, Nov 12 is a Friday in 2021
+        day_one = exchanger.get_day_one(datetime("2021-11-12"))
+        self.assertEqual(day_one, date("2021-11-10"))
+
+    def test_get_day_one_skips_new_year(self):
+        exchanger = Exchanger(None, Calendar())
+        # Jan 1, 2025 is Wednesday (holiday)
+        # day-1 from Jan 2 = Jan 1 (holiday) → Dec 31, 2024 (Tuesday, workday)
+        day_one = exchanger.get_day_one(datetime("2025-01-02"))
+        self.assertEqual(day_one, date("2024-12-31"))

--- a/tests/test_per_stock_calculator.py
+++ b/tests/test_per_stock_calculator.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from pit38.domain.stock.profit.per_stock_calculator import PerStockProfitCalculator
-from tests.utils import StubExchanger, apple, usd, buy, sell, zl
+from tests.utils import StubExchanger, DateAwareExchanger, apple, usd, buy, sell, zl
 
 
 class TestPerStockProfitCalculator(TestCase):
@@ -100,3 +100,40 @@ class TestPerStockProfitCalculator(TestCase):
 
         self.assertEqual(profit.get_cost(2022), zl(20000))
         self.assertEqual(profit.get_income(2022), zl(22000))
+
+    def test_partial_sell(self):
+        calculator = PerStockProfitCalculator(StubExchanger())
+        transactions = [
+            buy(apple(10), usd(1000), "2020-01-01 12:00"),
+            sell(apple(3), usd(400), "2020-06-01 12:00"),
+        ]
+        profit = calculator.calculate_cost_and_income(transactions)
+
+        self.assertEqual(profit.get_cost(2020), zl(1200))
+        self.assertEqual(profit.get_income(2020), zl(1600))
+
+    def test_partial_sell_uses_buy_date_exchange_rate(self):
+        exchanger = DateAwareExchanger({
+            "2020-01": 4.0,
+            "2020-06": 5.0,
+        })
+        calculator = PerStockProfitCalculator(exchanger)
+        transactions = [
+            buy(apple(10), usd(1000), "2020-01-15 12:00"),
+            sell(apple(3), usd(400), "2020-06-15 12:00"),
+        ]
+        profit = calculator.calculate_cost_and_income(transactions)
+
+        # cost: 3/10 * 1000 USD * 4.0 (BUY date rate) = 1200 PLN
+        self.assertEqual(profit.get_cost(2020), zl(1200))
+        # income: 400 USD * 5.0 (SELL date rate) = 2000 PLN
+        self.assertEqual(profit.get_income(2020), zl(2000))
+
+    def test_sell_without_buy_raises_error(self):
+        calculator = PerStockProfitCalculator(StubExchanger())
+        transactions = [
+            sell(apple(1), usd(200), "2020-01-01 12:00"),
+        ]
+        with self.assertRaises(ValueError) as ctx:
+            calculator.calculate_cost_and_income(transactions)
+        self.assertIn("No buy transaction", str(ctx.exception))

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -59,14 +59,17 @@ class TestTaxCalculator(TestCase):
         cost = {2019: zl(100), 2020: zl(100), 2021: zl(100)}
         profit = ProfitPerYear(income, cost)
 
-        base_for_tax_2019 = tax_calculator.calculate_tax_per_year(profit, 2019).base_for_tax
-        self.assertEqual(zl(100), base_for_tax_2019)
+        result_2019 = tax_calculator.calculate_tax_per_year(profit, 2019)
+        self.assertEqual(zl(100), result_2019.base_for_tax)
+        self.assertEqual(zl(19), result_2019.tax)
 
-        base_for_tax_2020 = tax_calculator.calculate_tax_per_year(profit, 2020).base_for_tax
-        self.assertEqual(zl(100), base_for_tax_2020)
+        result_2020 = tax_calculator.calculate_tax_per_year(profit, 2020)
+        self.assertEqual(zl(100), result_2020.base_for_tax)
+        self.assertEqual(zl(19), result_2020.tax)
 
-        base_for_tax_2021 = tax_calculator.calculate_tax_per_year(profit, 2021).base_for_tax
-        self.assertEqual(zl(100), base_for_tax_2021)
+        result_2021 = tax_calculator.calculate_tax_per_year(profit, 2021)
+        self.assertEqual(zl(100), result_2021.base_for_tax)
+        self.assertEqual(zl(19), result_2021.tax)
 
     def test_calculate_tax_per_year_hodl(self):
         tax_calculator = TaxCalculator()
@@ -75,14 +78,17 @@ class TestTaxCalculator(TestCase):
         cost = {2019: zl(100), 2020: zl(100), 2021: zl(100)}
         profit = ProfitPerYear(income, cost)
 
-        base_for_tax_2019 = tax_calculator.calculate_tax_per_year(profit, 2019).base_for_tax
-        self.assertEqual(zl(-100), base_for_tax_2019)
+        result_2019 = tax_calculator.calculate_tax_per_year(profit, 2019)
+        self.assertEqual(zl(-100), result_2019.base_for_tax)
+        self.assertEqual(zl(0), result_2019.tax)
 
-        base_for_tax_2020 = tax_calculator.calculate_tax_per_year(profit, 2020).base_for_tax
-        self.assertEqual(zl(-200), base_for_tax_2020)
+        result_2020 = tax_calculator.calculate_tax_per_year(profit, 2020)
+        self.assertEqual(zl(-200), result_2020.base_for_tax)
+        self.assertEqual(zl(0), result_2020.tax)
 
-        base_for_tax_2021 = tax_calculator.calculate_tax_per_year(profit, 2021).base_for_tax
-        self.assertEqual(zl(700), base_for_tax_2021)
+        result_2021 = tax_calculator.calculate_tax_per_year(profit, 2021)
+        self.assertEqual(zl(700), result_2021.base_for_tax)
+        self.assertEqual(zl(133), result_2021.tax)
 
     def test_calculate_tax_per_year_losses(self):
         tax_calculator = TaxCalculator()
@@ -91,12 +97,38 @@ class TestTaxCalculator(TestCase):
         cost = {2019: zl(200), 2020: zl(200), 2021: zl(100)}
         profit = ProfitPerYear(income, cost)
 
-        base_for_tax_2019 = tax_calculator.calculate_tax_per_year(profit, 2019).base_for_tax
-        self.assertEqual(zl(-150), base_for_tax_2019)
+        result_2019 = tax_calculator.calculate_tax_per_year(profit, 2019)
+        self.assertEqual(zl(-150), result_2019.base_for_tax)
+        self.assertEqual(zl(0), result_2019.tax)
 
-        base_for_tax_2020 = tax_calculator.calculate_tax_per_year(profit, 2020).base_for_tax
-        self.assertEqual(zl(-300), base_for_tax_2020)
+        result_2020 = tax_calculator.calculate_tax_per_year(profit, 2020)
+        self.assertEqual(zl(-300), result_2020.base_for_tax)
+        self.assertEqual(zl(0), result_2020.tax)
 
-        base_for_tax_2021 = tax_calculator.calculate_tax_per_year(profit, 2021).base_for_tax
+        result_2021 = tax_calculator.calculate_tax_per_year(profit, 2021)
         # 300 losses from previous years deducted
-        self.assertEqual(zl(100), base_for_tax_2021)
+        self.assertEqual(zl(100), result_2021.base_for_tax)
+        self.assertEqual(zl(19), result_2021.tax)
+
+    def test_tax_is_zero_when_loss(self):
+        tax_calculator = TaxCalculator()
+
+        income = {2021: zl(100)}
+        cost = {2021: zl(500)}
+        profit = ProfitPerYear(income, cost)
+
+        result = tax_calculator.calculate_tax_per_year(profit, 2021)
+        self.assertEqual(zl(-400), result.base_for_tax)
+        self.assertEqual(zl(0), result.tax)
+
+    def test_manual_deductible_loss(self):
+        tax_calculator = TaxCalculator()
+
+        income = {2020: zl(100), 2021: zl(1000)}
+        cost = {2020: zl(200), 2021: zl(100)}
+        profit = ProfitPerYear(income, cost)
+
+        result = tax_calculator.calculate_tax_per_year(profit, 2021, deductible_loss=500)
+        self.assertEqual(zl(500), result.deductible_loss)
+        self.assertEqual(zl(400), result.base_for_tax)
+        self.assertEqual(zl(76), result.tax)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,6 +11,10 @@ def btc(amount: float) -> AssetValue:
     return AssetValue(amount, "BTC")
 
 
+def eth(amount: float) -> AssetValue:
+    return AssetValue(amount, "ETH")
+
+
 def apple(amount: float) -> AssetValue:
     return AssetValue(amount, "AAPL")
 
@@ -69,3 +73,16 @@ class StubExchanger:
         if fiat_value.currency == Currency.DOLLAR:
             return FiatValue(fiat_value.amount * 4.0, Currency.ZLOTY)
         return FiatValue(fiat_value.amount, Currency.ZLOTY)
+
+
+class DateAwareExchanger:
+    """Exchanger that returns different rates based on the date's month."""
+    def __init__(self, rates: dict[str, float]):
+        self.rates = rates
+
+    def exchange(self, date: pendulum.DateTime, fiat_value: FiatValue) -> FiatValue:
+        date_key = date.format("YYYY-MM-DD") if hasattr(date, 'format') else str(date)
+        for key, rate in self.rates.items():
+            if date_key.startswith(key):
+                return FiatValue(round(fiat_value.amount * rate, 2), Currency.ZLOTY)
+        return FiatValue(fiat_value.amount * 4.0, Currency.ZLOTY)


### PR DESCRIPTION
## Summary

- **Bug fix**: `per_stock_calculator.py` used the **sell date** instead of the **buy date** when converting partial sell cost to PLN — violates art. 23 ust. 1 pkt 38 ustawy o PIT. One-line fix: `transaction.date` → `oldest_buy.date`
- **10 new tests** closing gaps from TEST_GAPS.md (67 → 77 total):
  - Partial sell with date-aware exchanger (catches the bug)
  - Partial sell proportional cost
  - Sell without prior buy → `ValueError`
  - Tax amount (19%) assertions on all tax tests
  - Tax = 0 when loss (not negative)
  - Manual `deductible_loss` parameter
  - Crypto: cross-year buy/sell, buy-only, multiple cryptocurrencies
  - Exchanger: Polish holidays (Independence Day, New Year)
- **Test utils**: `DateAwareExchanger` (date-dependent rates) and `eth()` helper

## Test plan

- [x] `.venv/bin/python -m pytest tests/ -v` — 77/77 pass
- [x] `test_partial_sell_uses_buy_date_exchange_rate` fails before bug fix, passes after
- [x] Existing tests unaffected (strengthened with `.tax` assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)