### PR TITLE
Add CI badges and Codecov coverage integration

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
 name: Python application
 
 on:
@@ -34,4 +31,12 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: Test with pytest
       run: |
-        pytest tests/
+        pytest tests/ --cov=pit38 --cov-report=xml --cov-report=term
+    - name: Upload coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@v5
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: false
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,7 +31,7 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: Test with pytest
       run: |
-        pytest tests/ --cov=pit38 --cov-report=xml --cov-report=term
+        pytest tests/ --cov=pit38 --cov-branch --cov-report=xml --cov-report=term
     - name: Upload coverage to Codecov
       if: always()
       uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # PIT-38 — Polish Investment Tax Calculator
 
+[![CI](https://github.com/pbialon/pit-38/actions/workflows/python-app.yml/badge.svg)](https://github.com/pbialon/pit-38/actions/workflows/python-app.yml)
+[![codecov](https://codecov.io/gh/pbialon/pit-38/graph/badge.svg)](https://codecov.io/gh/pbialon/pit-38)
+[![GitHub release](https://img.shields.io/github/v/release/pbialon/pit-38)](https://github.com/pbialon/pit-38/releases)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+
 > **[&#127477;&#127473; Wersja polska](README.pl.md)**
 
 A command-line tool for calculating Polish income tax on **stocks** and **cryptocurrency** (PIT-38 form). It imports transaction history from popular brokers, converts foreign currencies to PLN using official NBP exchange rates, and computes your tax liability.

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,5 +1,11 @@
 # PIT-38 — Kalkulator podatku od inwestycji
 
+[![CI](https://github.com/pbialon/pit-38/actions/workflows/python-app.yml/badge.svg)](https://github.com/pbialon/pit-38/actions/workflows/python-app.yml)
+[![codecov](https://codecov.io/gh/pbialon/pit-38/graph/badge.svg)](https://codecov.io/gh/pbialon/pit-38)
+[![GitHub release](https://img.shields.io/github/v/release/pbialon/pit-38)](https://github.com/pbialon/pit-38/releases)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+
 > **[&#127468;&#127463; English version](README.md)**
 
 Narzędzie wiersza poleceń do obliczania polskiego podatku dochodowego od **akcji** i **kryptowalut** (formularz PIT-38). Importuje historię transakcji z popularnych brokerów, przelicza waluty obce na PLN po kursach średnich NBP i oblicza wysokość podatku.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest~=8.1.1",
+    "pytest-cov~=5.0",
     "ipdb==0.13.13",
 ]
 


### PR DESCRIPTION
## Summary

- **README badges**: CI status, Codecov coverage, GitHub release, Python 3.10+, MIT license
- **Codecov integration**: `pytest-cov` with `--cov-branch`, XML report upload via `codecov/codecov-action@v5`
- Current coverage: **92%** (line), branch coverage enabled

## Setup required

1. Add `CODECOV_TOKEN` as GitHub repo secret (Settings → Secrets → Actions)
2. Merge this PR

## Test plan

- [x] `pytest tests/ --cov=pit38 --cov-branch --cov-report=term` — 92/92 pass, 92% coverage
- [x] CI workflow updated, Codecov upload step added

🤖 Generated with [Claude Code](https://claude.com/claude-code)