### PR TITLE
Add Codecov Test Analytics

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,7 +31,7 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: Test with pytest
       run: |
-        pytest tests/ --cov=pit38 --cov-branch --cov-report=xml --cov-report=term
+        pytest tests/ --cov=pit38 --cov-branch --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
     - name: Upload coverage to Codecov
       if: always()
       uses: codecov/codecov-action@v5
@@ -40,3 +40,8 @@ jobs:
         fail_ci_if_error: false
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Add JUnit XML output to pytest (`--junitxml=junit.xml -o junit_family=legacy`)
- Add `codecov/test-results-action@v1` step to upload test results
- Enables test run time tracking, failure rate analysis, and flaky test detection in Codecov

## Test plan
- [ ] CI workflow runs successfully
- [ ] Codecov Test Analytics dashboard shows test results after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)