### PR TITLE
fix: codecov-action v5 file → files param

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,7 +36,7 @@ jobs:
       if: always()
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Fix `file` → `files` parameter in `codecov/codecov-action@v5` (v5 renamed the input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)