### PR TITLE
Add rich CLI output with colored panels and formatted tables

### DIFF
--- a/pit38/crypto.py
+++ b/pit38/crypto.py
@@ -9,6 +9,7 @@ from pit38.domain.crypto.profit_calculator import YearlyProfitCalculator
 from pit38.domain.tax_service.crypto_tax_calculator import CryptoTaxCalculator
 from pit38.domain.transactions import Transaction
 from pit38.exchanger import create_exchanger
+from pit38.output import print_crypto_result
 from loguru import logger
 import sys
 
@@ -47,7 +48,11 @@ def crypto(tax_year: int, filepaths: tuple[str, ...], deductible_loss: float, lo
     profit_per_year = profit_calculator.profit_per_year(all_transactions)
     tax_calculator = CryptoTaxCalculator()
     tax_data = tax_calculator.calculate_tax_per_year(profit_per_year, tax_year, deductible_loss)
-    print(tax_data, end='\n\n')
+    print_crypto_result(
+        tax_data,
+        num_transactions=len(all_transactions),
+        num_files=len(filepaths),
+    )
 
 
 if __name__ == "__main__":

--- a/pit38/domain/tax_service/tax_year_result.py
+++ b/pit38/domain/tax_service/tax_year_result.py
@@ -14,8 +14,10 @@ class TaxYearResult:
         self.tax = tax
 
     def __str__(self):
-        return f"[Tax year {self.tax_year}]: \n" \
-               f"income: +{self.income} ZŁ, outcome: -{self.cost}\n" \
-               f"deductible loss: {self.deductible_loss} ZŁ\n" \
-               f"base for tax: {self.base_for_tax} ZŁ\n" \
-               f"tax: {self.tax} ZŁ"
+        return (
+            f"[Tax year {self.tax_year}]: "
+            f"income: +{self.income}, cost: -{self.cost}, "
+            f"deductible loss: {self.deductible_loss}, "
+            f"base for tax: {self.base_for_tax}, "
+            f"tax: {self.tax}"
+        )

--- a/pit38/output.py
+++ b/pit38/output.py
@@ -94,9 +94,9 @@ def print_stock_result(
 
     console.print()
     console.print(_build_section("Dividends", dividends_result))
-    console.print(
-        "  [dim italic]ℹ W-8BEN: 15% US withheld → 4% PL tax due[/]"
-    )
+    console.print("  [dim italic]ℹ Dividends from US stocks:[/]")
+    console.print("  [dim italic]  • With W-8BEN form:  15% US tax withheld → pay 4% in Poland (19% - 15%)[/]")
+    console.print("  [dim italic]  • Without W-8BEN:    30% US tax withheld → no Polish tax due[/]")
 
     console.print()
     console.print(

--- a/pit38/output.py
+++ b/pit38/output.py
@@ -1,0 +1,118 @@
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from pit38.domain.tax_service.tax_year_result import TaxYearResult
+
+console = Console()
+
+
+def _fmt(amount: float) -> str:
+    return f"{amount:,.2f} PLN".replace(",", " ")
+
+
+def _colored_amount(amount: float, positive_color="green", negative_color="red") -> str:
+    formatted = _fmt(abs(amount))
+    if amount > 0:
+        return f"[{positive_color}]+ {formatted}[/]"
+    if amount < 0:
+        return f"[{negative_color}]- {formatted}[/]"
+    return f"  {formatted}"
+
+
+def _tax_base_styled(amount: float) -> str:
+    formatted = _fmt(abs(amount))
+    if amount < 0:
+        return f"[bold red]- {formatted}[/]"
+    return f"[bold]  {formatted}[/]"
+
+
+def _tax_styled(amount: float) -> str:
+    formatted = _fmt(amount)
+    if amount == 0:
+        return f"[bold green]  {formatted}[/]"
+    return f"[bold red]  {formatted}[/]"
+
+
+def _build_tax_table(title: str, result: TaxYearResult) -> Table:
+    table = Table(
+        show_header=False,
+        box=None,
+        padding=(0, 2),
+        title=f"[bold]{title}[/]",
+        title_style="",
+        title_justify="left",
+    )
+    table.add_column(min_width=22)
+    table.add_column(justify="right", min_width=18)
+
+    table.add_row("Income (przychód)", _colored_amount(result.income.amount))
+    table.add_row("Cost (koszty)", _colored_amount(-result.cost.amount))
+    if result.deductible_loss.amount > 0:
+        table.add_row(
+            "Deductible loss",
+            f"[yellow]- {_fmt(result.deductible_loss.amount)}[/]",
+        )
+    table.add_row("", "")
+    table.add_row("Tax base", _tax_base_styled(result.base_for_tax.amount))
+    table.add_row("Tax (19%)", _tax_styled(result.tax.amount))
+
+    return table
+
+
+def print_stock_result(
+    transactions_result: TaxYearResult,
+    dividends_result: TaxYearResult,
+    num_transactions: int,
+    num_files: int,
+):
+    console.print()
+    console.print(
+        Panel(
+            f"[bold]PIT-38 Stock Tax Summary — {transactions_result.tax_year}[/]",
+            style="cyan",
+            expand=False,
+        )
+    )
+    console.print()
+
+    console.print(_build_tax_table("Transactions", transactions_result))
+    console.print()
+
+    console.print(_build_tax_table("Dividends", dividends_result))
+    console.print(
+        "  [dim italic]If you paid 30% withholding tax in the US (no W-8BEN),[/]",
+    )
+    console.print(
+        "  [dim italic]no additional Polish tax is due on dividends.[/]",
+    )
+    console.print()
+
+    console.print(
+        f"  [dim]Processed {num_transactions} transactions from {num_files} file(s).[/]"
+    )
+    console.print()
+
+
+def print_crypto_result(
+    result: TaxYearResult,
+    num_transactions: int,
+    num_files: int,
+):
+    console.print()
+    console.print(
+        Panel(
+            f"[bold]PIT-38 Crypto Tax Summary — {result.tax_year}[/]",
+            style="cyan",
+            expand=False,
+        )
+    )
+    console.print()
+
+    console.print(_build_tax_table("Crypto", result))
+    console.print()
+
+    console.print(
+        f"  [dim]Processed {num_transactions} transactions from {num_files} file(s).[/]"
+    )
+    console.print()

--- a/pit38/output.py
+++ b/pit38/output.py
@@ -1,10 +1,14 @@
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
 
 from pit38.domain.tax_service.tax_year_result import TaxYearResult
 
 console = Console()
+
+SEP_THIN = "───────────────"
+SEP_BOLD = "═══════════════"
 
 
 def _fmt(amount: float) -> str:
@@ -34,30 +38,40 @@ def _tax_styled(amount: float) -> str:
     return f"[bold red]  {formatted}[/]"
 
 
-def _build_tax_table(title: str, result: TaxYearResult) -> Table:
+def _build_section(title: str, result: TaxYearResult, note: str = None) -> Panel:
     table = Table(
         show_header=False,
         box=None,
-        padding=(0, 2),
-        title=f"[bold]{title}[/]",
-        title_style="",
-        title_justify="left",
+        padding=(0, 1),
+        expand=True,
     )
     table.add_column(min_width=22)
-    table.add_column(justify="right", min_width=18)
+    table.add_column(justify="right", min_width=17)
 
-    table.add_row("Income (przychód)", _colored_amount(result.income.amount))
-    table.add_row("Cost (koszty)", _colored_amount(-result.cost.amount))
+    income = result.income.amount
+    cost = result.cost.amount
+    profit = income - cost
+
+    table.add_row("Income (przychód)", _colored_amount(income))
+    table.add_row("Cost (koszty)", _colored_amount(-cost))
+    table.add_row("", f"[dim]{SEP_THIN}[/]")
+    table.add_row("Profit", _colored_amount(profit))
+
     if result.deductible_loss.amount > 0:
         table.add_row(
             "Deductible loss",
             f"[yellow]- {_fmt(result.deductible_loss.amount)}[/]",
         )
-    table.add_row("", "")
+
+    table.add_row("", f"[dim]{SEP_BOLD}[/]")
     table.add_row("Tax base", _tax_base_styled(result.base_for_tax.amount))
     table.add_row("Tax (19%)", _tax_styled(result.tax.amount))
 
-    return table
+    if note:
+        table.add_row("", "")
+        table.add_row(f"[dim italic]{note}[/]", "")
+
+    return Panel(table, title=f"[bold]{title}[/]", title_align="left", border_style="dim", expand=False, width=52)
 
 
 def print_stock_result(
@@ -74,20 +88,17 @@ def print_stock_result(
             expand=False,
         )
     )
-    console.print()
 
-    console.print(_build_tax_table("Transactions", transactions_result))
     console.print()
+    console.print(_build_section("Transactions", transactions_result))
 
-    console.print(_build_tax_table("Dividends", dividends_result))
+    console.print()
+    console.print(_build_section("Dividends", dividends_result))
     console.print(
-        "  [dim italic]If you paid 30% withholding tax in the US (no W-8BEN),[/]",
+        "  [dim italic]ℹ W-8BEN: 15% US withheld → 4% PL tax due[/]"
     )
-    console.print(
-        "  [dim italic]no additional Polish tax is due on dividends.[/]",
-    )
-    console.print()
 
+    console.print()
     console.print(
         f"  [dim]Processed {num_transactions} transactions from {num_files} file(s).[/]"
     )
@@ -107,11 +118,11 @@ def print_crypto_result(
             expand=False,
         )
     )
-    console.print()
 
-    console.print(_build_tax_table("Crypto", result))
     console.print()
+    console.print(_build_section("Crypto", result))
 
+    console.print()
     console.print(
         f"  [dim]Processed {num_transactions} transactions from {num_files} file(s).[/]"
     )

--- a/pit38/stock.py
+++ b/pit38/stock.py
@@ -15,6 +15,7 @@ from pit38.domain.stock.profit.profit_calculator import ProfitCalculator
 from pit38.domain.tax_service.stock_tax_calculator import StockTaxCalculator
 from pit38.domain.transactions.transaction import Transaction
 from pit38.exchanger import create_exchanger
+from pit38.output import print_stock_result
 
 class StockSetup:
 
@@ -88,8 +89,12 @@ def stocks(tax_year: int, filepaths: tuple[str, ...], deductible_loss: float, lo
     tax_data_from_dividends = tax_calculator.calculate_tax_per_year(
         profit_from_dividends, tax_year, 0)
 
-    print("\n\nTransactions: ", tax_data_from_transactions, end='\n\n')
-    print("Dividends (if you paid 30% in USA you don't have to pay):", tax_data_from_dividends, end='\n\n')
+    print_stock_result(
+        tax_data_from_transactions,
+        tax_data_from_dividends,
+        num_transactions=len(transactions),
+        num_files=len(filepaths),
+    )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "holidays~=0.46",
     "requests~=2.31.0",
     "click~=8.1.3",
+    "rich~=13.7",
     "pandas~=2.2.2",
     "openpyxl~=3.1.2",
 ]

--- a/tests/e2e/test_cli_e2e.py
+++ b/tests/e2e/test_cli_e2e.py
@@ -34,7 +34,7 @@ class TestStockCLI(TestCase):
         result = runner.invoke(stocks, ["-f", csv_path, "-y", "2024", "-ll", "ERROR"])
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("Transactions:", result.output)
+        self.assertIn("Stock Tax Summary", result.output)
 
 
 class TestCryptoCLI(TestCase):


### PR DESCRIPTION
## Summary

- **Rich-based output** replacing raw `print()` — colored, structured, receipt-like layout
- **Paneled sections**: Transactions, Dividends, Crypto each in bordered panels
- **Profit row** with thin `───` separator (income - cost)
- **Bold separator** `═══` before Tax base / Tax (19%)
- **Color scheme**: green (income), red (costs/tax), yellow (deductible loss), bold green (tax=0)
- **Formatted amounts**: thousand separators (`22 000.00 PLN`)
- **Fix**: removed "PLN ZŁ" double unit from `TaxYearResult.__str__()`
- Added `rich` as production dependency

## Before / After

**Before:**
```
Transactions:  [Tax year 2025]:
income: +22000 PLN ZŁ, outcome: -15000 PLN
deductible loss: 2000 PLN ZŁ
base for tax: 5000 PLN ZŁ
tax: 950 PLN ZŁ
```

**After:**
```
╭─ Transactions ──────────────────────────────╮
│  Income (przychód)         + 22 000.00 PLN  │
│  Cost (koszty)             - 15 000.00 PLN  │
│                            ───────────────  │
│  Profit                     + 7 000.00 PLN  │
│  Deductible loss            - 2 000.00 PLN  │
│                            ═══════════════  │
│  Tax base                     5 000.00 PLN  │
│  Tax (19%)                      950.00 PLN  │
╰─────────────────────────────────────────────╯
```

## Test plan

- [x] `pytest tests/ -v` — 92/92 pass
- [x] E2E CLI tests updated to match new output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)