### PR TITLE
refactor: split enums into Action and StockMarketOperation (#53)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ resources/*
 *.egg-info/
 dist/
 build/
+
+# pytest-cov artefacts
+.coverage
+.coverage.*
+htmlcov/

--- a/TAX_LAW_AUDIT.md
+++ b/TAX_LAW_AUDIT.md
@@ -7,12 +7,12 @@ Performed April 2026.
 
 ## Summary
 
-| # | Issue | Severity | Tax Impact |
-|---|-------|----------|------------|
-| 1 | OperationType vs Action type mismatch | Low | None currently |
-| 2 | Rounding to full PLN | Minor | Cosmetic |
-| 3 | Dividend withholding tax | Moderate | Under/overpayment |
-| 4 | Commission fees | Low | Depends on broker |
+| # | Issue | Severity | Tax Impact | Status |
+|---|-------|----------|------------|--------|
+| 1 | OperationType vs Action type mismatch | Low | None currently | ✅ Resolved (#53) |
+| 2 | Rounding to full PLN | Minor | Cosmetic | Open (#52) |
+| 3 | Dividend withholding tax | Moderate | Under/overpayment | Open (#51) |
+| 4 | Commission fees | Low | Depends on broker | Open |
 
 ## What's Correct
 
@@ -32,12 +32,19 @@ Performed April 2026.
 
 ## Open Issues
 
-### 1. OperationType vs Action type mismatch
+### 1. OperationType vs Action type mismatch ✅ RESOLVED
 
-**File:** `pit38/plugins/stock/revolut/transaction_row_parser.py:31`
+Resolved by splitting the responsibility into two enums with clear roles (see #53):
 
-`_operation_type()` returns `OperationType.BUY` but `Transaction` expects
-`Action.BUY`. Works because both have `.value = "BUY"`. Fragile, no tax impact.
+- `Action(BUY, SELL)` — the transactional action, attribute of `Transaction`.
+  Common to stocks and crypto.
+- `StockMarketOperation(BUY, SELL, DIVIDEND, SERVICE_FEE, STOCK_SPLIT)` —
+  classifier for rows in a stock-market CSV. Stock-specific; crypto CSV uses
+  `Action` directly.
+
+Silent `.value`-based coercion from `OperationType` to `Action` in the stock
+factory is replaced by an explicit `StockMarketOperation.to_action()` method
+that raises for non-transactional values.
 
 ### 2. Rounding to full PLN
 

--- a/pit38/data_sources/stock_loader/csv_loader.py
+++ b/pit38/data_sources/stock_loader/csv_loader.py
@@ -3,7 +3,8 @@ from typing import List, Optional
 import pendulum
 from loguru import logger
 
-from pit38.domain.stock.operations.operation import Operation, OperationType
+from pit38.domain.stock.operations.operation import Operation
+from pit38.domain.stock.operations.stock_market_operation import StockMarketOperation
 from pit38.data_sources.stock_loader.factory import OperationFactory
 from pit38.domain.currency_exchange_service.currencies import CurrencyBuilder, FiatValue, InvalidCurrencyException
 from pit38.domain.transactions.asset import AssetValue
@@ -74,9 +75,9 @@ class Loader:
             raise ValueError(f"Failed to parse currency: {str(e)}")
 
     @classmethod
-    def _operation_type(cls, row: dict) -> OperationType:
+    def _operation_type(cls, row: dict) -> StockMarketOperation:
         try:
-            return OperationType[row["operation"]]
+            return StockMarketOperation[row["operation"]]
         except (KeyError, ValueError) as e:
             raise ValueError(f"Failed to parse operation type: {str(e)}")
 

--- a/pit38/data_sources/stock_loader/factory.py
+++ b/pit38/data_sources/stock_loader/factory.py
@@ -1,35 +1,50 @@
 import pendulum
 from typing import Optional
 
-from pit38.domain.stock.operations.operation import Operation, OperationType
+from pit38.domain.stock.operations.operation import Operation
 from pit38.domain.stock.operations.service_fee import ServiceFee
 from pit38.domain.stock.operations.dividend import Dividend
+from pit38.domain.stock.operations.stock_market_operation import StockMarketOperation
 from pit38.domain.stock.operations.stock_split import StockSplit
 from pit38.domain.currency_exchange_service.currencies import FiatValue
-from pit38.domain.transactions.action import Action
 from pit38.domain.transactions.asset import AssetValue
 from pit38.domain.transactions.transaction import Transaction
 
 class OperationFactory:
     _creators = {
-        OperationType.SERVICE_FEE: lambda date, asset, fiat_value: ServiceFee(date=date, value=fiat_value),
-        OperationType.DIVIDEND: lambda date, asset, fiat_value: Dividend(date=date, value=fiat_value),
-        OperationType.STOCK_SPLIT: lambda date, asset, fiat_value: StockSplit(date=date, stock=asset.asset_name, ratio=int(asset.amount)),
-        OperationType.BUY: lambda date, asset, fiat_value: Transaction(date=date, action=Action.BUY, asset=asset, fiat_value=fiat_value),
-        OperationType.SELL: lambda date, asset, fiat_value: Transaction(date=date, action=Action.SELL, asset=asset, fiat_value=fiat_value),
-
+        StockMarketOperation.SERVICE_FEE: lambda date, asset, fiat_value: ServiceFee(
+            date=date, value=fiat_value,
+        ),
+        StockMarketOperation.DIVIDEND: lambda date, asset, fiat_value: Dividend(
+            date=date, value=fiat_value,
+        ),
+        StockMarketOperation.STOCK_SPLIT: lambda date, asset, fiat_value: StockSplit(
+            date=date, stock=asset.asset_name, ratio=int(asset.amount),
+        ),
+        StockMarketOperation.BUY: lambda date, asset, fiat_value: Transaction(
+            date=date,
+            action=StockMarketOperation.BUY.to_action(),
+            asset=asset,
+            fiat_value=fiat_value,
+        ),
+        StockMarketOperation.SELL: lambda date, asset, fiat_value: Transaction(
+            date=date,
+            action=StockMarketOperation.SELL.to_action(),
+            asset=asset,
+            fiat_value=fiat_value,
+        ),
     }
 
     @classmethod
     def create_operation(
         cls,
-        operation_type: OperationType,
+        operation_type: StockMarketOperation,
         date: pendulum.DateTime,
         asset: Optional[AssetValue] = None,
         fiat_value: Optional[FiatValue] = None,
     ) -> Operation:
         creator = cls._creators.get(operation_type)
         if not creator:
-            raise ValueError(f"Invalid operation type: {operation_type}")
-        
+            raise ValueError(f"Invalid stock market operation: {operation_type}")
+
         return creator(date, asset, fiat_value)

--- a/pit38/domain/stock/operations/dividend.py
+++ b/pit38/domain/stock/operations/dividend.py
@@ -1,11 +1,12 @@
 import pendulum
 
 from pit38.domain.currency_exchange_service.currencies import FiatValue
-from pit38.domain.stock.operations.operation import Operation, OperationType
+from pit38.domain.stock.operations.operation import Operation
+from pit38.domain.stock.operations.stock_market_operation import StockMarketOperation
 
 
 class Dividend(Operation):
-    type = OperationType.DIVIDEND
+    type = StockMarketOperation.DIVIDEND
 
     def __init__(self, date: pendulum.DateTime, value: FiatValue):
         self.date = date

--- a/pit38/domain/stock/operations/operation.py
+++ b/pit38/domain/stock/operations/operation.py
@@ -1,16 +1,2 @@
-import enum
-
-
 class Operation:
     type = None
-
-
-class OperationType(enum.Enum):
-    BUY = "BUY"
-    SELL = "SELL"
-    DIVIDEND = "DIVIDEND"
-    SERVICE_FEE = "SERVICE_FEE"
-    STOCK_SPLIT = "STOCK_SPLIT"
-
-    def __str__(self):
-        return self.value

--- a/pit38/domain/stock/operations/service_fee.py
+++ b/pit38/domain/stock/operations/service_fee.py
@@ -1,11 +1,12 @@
 import pendulum
 
 from pit38.domain.currency_exchange_service.currencies import FiatValue
-from pit38.domain.stock.operations.operation import Operation, OperationType
+from pit38.domain.stock.operations.operation import Operation
+from pit38.domain.stock.operations.stock_market_operation import StockMarketOperation
 
 
 class ServiceFee(Operation):
-    type = OperationType.SERVICE_FEE
+    type = StockMarketOperation.SERVICE_FEE
 
     def __init__(self, date: pendulum.DateTime, value: FiatValue):
         self.date = date

--- a/pit38/domain/stock/operations/stock_market_operation.py
+++ b/pit38/domain/stock/operations/stock_market_operation.py
@@ -1,0 +1,42 @@
+import enum
+from typing import List
+
+from pit38.domain.transactions.action import Action
+
+
+class StockMarketOperation(enum.Enum):
+    """Classification of a row in a stock-market CSV.
+
+    Includes transactions (BUY/SELL), income events (DIVIDEND),
+    service costs (SERVICE_FEE), and corporate actions (STOCK_SPLIT).
+
+    Crypto CSVs do not use this enum — crypto rows only represent
+    transactions, so they're classified by Action directly.
+    """
+    BUY = "BUY"
+    SELL = "SELL"
+    DIVIDEND = "DIVIDEND"
+    SERVICE_FEE = "SERVICE_FEE"
+    STOCK_SPLIT = "STOCK_SPLIT"
+
+    def __str__(self):
+        return self.value
+
+    def is_transaction(self) -> bool:
+        return self in (StockMarketOperation.BUY, StockMarketOperation.SELL)
+
+    def to_action(self) -> Action:
+        """Convert a transactional operation into the common Action enum.
+
+        Raises ValueError for non-transactional operations (DIVIDEND,
+        SERVICE_FEE, STOCK_SPLIT).
+        """
+        if self is StockMarketOperation.BUY:
+            return Action.BUY
+        if self is StockMarketOperation.SELL:
+            return Action.SELL
+        raise ValueError(f"{self} is not a transactional operation")
+
+    @classmethod
+    def available_operations(cls) -> List[str]:
+        return [op.value for op in cls]

--- a/pit38/domain/stock/operations/stock_split.py
+++ b/pit38/domain/stock/operations/stock_split.py
@@ -1,10 +1,11 @@
 import pendulum
 
-from pit38.domain.stock.operations.operation import Operation, OperationType
+from pit38.domain.stock.operations.operation import Operation
+from pit38.domain.stock.operations.stock_market_operation import StockMarketOperation
 
 
 class StockSplit(Operation):
-    type = OperationType.STOCK_SPLIT
+    type = StockMarketOperation.STOCK_SPLIT
 
     def __init__(self, date: pendulum.DateTime, stock: str, ratio: int):
         self.date = date

--- a/pit38/domain/transactions/action.py
+++ b/pit38/domain/transactions/action.py
@@ -3,6 +3,12 @@ from typing import List
 
 
 class Action(enum.Enum):
+    """Transaction action: what the user did with an asset.
+
+    Common to both stocks and crypto — every Transaction has an action.
+    Non-transactional events on the stock market (dividends, fees, splits)
+    are classified separately via StockMarketOperation.
+    """
     BUY = "BUY"
     SELL = "SELL"
 
@@ -10,9 +16,13 @@ class Action(enum.Enum):
         return self.value
 
     def __eq__(self, other):
+        if other is None:
+            return False
         return self.value == other.value
+
+    def __hash__(self):
+        return hash(self.value)
 
     @classmethod
     def available_actions(cls) -> List[str]:
-        # BUY, SELL
         return [action.value for action in cls]

--- a/pit38/plugins/stock/revolut/operation_row_parser.py
+++ b/pit38/plugins/stock/revolut/operation_row_parser.py
@@ -2,30 +2,31 @@ from typing import Dict
 
 import pendulum
 
-from pit38.domain.stock.operations.service_fee import ServiceFee
 from pit38.domain.stock.operations.dividend import Dividend
-from pit38.domain.stock.operations.operation import Operation, OperationType
+from pit38.domain.stock.operations.operation import Operation
+from pit38.domain.stock.operations.service_fee import ServiceFee
+from pit38.domain.stock.operations.stock_market_operation import StockMarketOperation
 from pit38.domain.stock.operations.stock_split import StockSplit
 from pit38.plugins.stock.revolut.row_parser import RowParser
 
 
 class OperationRowParser(RowParser):
     OPERATIONS_HANDLED = {
-        OperationType.DIVIDEND,
-        OperationType.SERVICE_FEE,
-        OperationType.STOCK_SPLIT
-    }   
+        StockMarketOperation.DIVIDEND,
+        StockMarketOperation.SERVICE_FEE,
+        StockMarketOperation.STOCK_SPLIT,
+    }
 
     @classmethod
     def parse(cls, row: Dict) -> Operation:
         operation_type = cls._operation_type(row)
         if operation_type not in cls.OPERATIONS_HANDLED:
             return None
-        if operation_type == OperationType.DIVIDEND:
+        if operation_type == StockMarketOperation.DIVIDEND:
             return cls._parse_dividend(row)
-        if operation_type == OperationType.SERVICE_FEE:
+        if operation_type == StockMarketOperation.SERVICE_FEE:
             return cls._parse_service_fee(row)
-        if operation_type == OperationType.STOCK_SPLIT:
+        if operation_type == StockMarketOperation.STOCK_SPLIT:
             return cls._parse_stock_split(row)
 
     @classmethod

--- a/pit38/plugins/stock/revolut/row_parser.py
+++ b/pit38/plugins/stock/revolut/row_parser.py
@@ -4,19 +4,19 @@ from typing import Dict
 import pendulum
 
 from pit38.domain.currency_exchange_service.currencies import Currency, FiatValue, CurrencyBuilder
+from pit38.domain.stock.operations.stock_market_operation import StockMarketOperation
 from pit38.domain.transactions import Transaction
-from pit38.domain.stock.operations.operation import OperationType
 
 
 class RowParser:
     OPERATIONS = {
-        "BUY - MARKET": OperationType.BUY,
-        "BUY - LIMIT": OperationType.BUY,
-        "SELL - MARKET": OperationType.SELL,
-        "SELL - LIMIT": OperationType.SELL,
-        "DIVIDEND": OperationType.DIVIDEND,
-        "CUSTODY FEE": OperationType.SERVICE_FEE,
-        "STOCK SPLIT": OperationType.STOCK_SPLIT,
+        "BUY - MARKET": StockMarketOperation.BUY,
+        "BUY - LIMIT": StockMarketOperation.BUY,
+        "SELL - MARKET": StockMarketOperation.SELL,
+        "SELL - LIMIT": StockMarketOperation.SELL,
+        "DIVIDEND": StockMarketOperation.DIVIDEND,
+        "CUSTODY FEE": StockMarketOperation.SERVICE_FEE,
+        "STOCK SPLIT": StockMarketOperation.STOCK_SPLIT,
     }
 
     @classmethod
@@ -66,5 +66,5 @@ class RowParser:
         return pendulum.parse(row['Date'])
 
     @classmethod
-    def _operation_type(cls, row: dict) -> OperationType:
+    def _operation_type(cls, row: dict) -> StockMarketOperation:
         return cls.OPERATIONS.get(row['Type'])

--- a/pit38/plugins/stock/revolut/transaction_row_parser.py
+++ b/pit38/plugins/stock/revolut/transaction_row_parser.py
@@ -2,15 +2,15 @@ from typing import Dict
 
 from loguru import logger
 
-from pit38.plugins.stock.revolut.row_parser import RowParser
-from pit38.domain.stock.operations.operation import OperationType
+from pit38.domain.stock.operations.stock_market_operation import StockMarketOperation
 from pit38.domain.transactions import Transaction, AssetValue
+from pit38.plugins.stock.revolut.row_parser import RowParser
 
 
 class TransactionRowParser(RowParser):
     OPERATIONS_HANDLED = {
-        OperationType.BUY,
-        OperationType.SELL,
+        StockMarketOperation.BUY,
+        StockMarketOperation.SELL,
     }
 
     @classmethod
@@ -28,7 +28,7 @@ class TransactionRowParser(RowParser):
         return Transaction(
             asset=cls._asset(row),
             fiat_value=cls._fiat_value(row),
-            action=cls._operation_type(row),
+            action=cls._operation_type(row).to_action(),
             date=cls._date(row),
         )
 

--- a/pit38/stock.py
+++ b/pit38/stock.py
@@ -7,8 +7,9 @@ from pit38.data_sources.stock_loader.csv_loader import Loader as StockLoader
 from pit38.data_sources.stock_loader.multi_sources_loader import MultiSourcesLoader
 from pit38.domain.calendar_service.calendar import previous_year
 from pit38.domain.stock.operations.dividend import Dividend
-from pit38.domain.stock.operations.operation import Operation, OperationType
+from pit38.domain.stock.operations.operation import Operation
 from pit38.domain.stock.operations.service_fee import ServiceFee
+from pit38.domain.stock.operations.stock_market_operation import StockMarketOperation
 from pit38.domain.stock.operations.stock_split import StockSplit
 from pit38.domain.stock.profit.per_stock_calculator import PerStockProfitCalculator
 from pit38.domain.stock.profit.profit_calculator import ProfitCalculator
@@ -44,19 +45,19 @@ class StockSetup:
 
     @classmethod
     def filter_transactions(cls, operations: List[Operation | Transaction]) -> List[Transaction]:
-        return [operation for operation in operations if operation.type in [OperationType.BUY, OperationType.SELL]]
+        return [op for op in operations if isinstance(op, Transaction)]
 
     @classmethod
     def filter_stock_splits(cls, operations: List[Operation]) -> List[StockSplit]:
-        return [operation for operation in operations if operation.type == OperationType.STOCK_SPLIT]
+        return [op for op in operations if op.type == StockMarketOperation.STOCK_SPLIT]
 
     @classmethod
     def filter_dividends(cls, operations: List[Operation]) -> List[Dividend]:
-        return [operation for operation in operations if operation.type == OperationType.DIVIDEND]
+        return [op for op in operations if op.type == StockMarketOperation.DIVIDEND]
 
     @classmethod
     def filter_service_fees(cls, operations: List[Operation]) -> List[ServiceFee]:
-        return [operation for operation in operations if operation.type == OperationType.SERVICE_FEE]
+        return [op for op in operations if op.type == StockMarketOperation.SERVICE_FEE]
 
 
 


### PR DESCRIPTION
Closes #53. Unblocks #9 sub-issues (#56, #57, #58).

## What changed from the first version of this PR

The first approach merged `OperationType` and `Action` into a single 5-value `Action` enum. Review feedback rightly pointed out that this loses a domain boundary: `Transaction(action=Action.STOCK_SPLIT)` would be syntactically valid, and `CsvValidator` (once wired in #9) would let a crypto CSV carry `STOCK_SPLIT` rows — neither makes sense.

This revised version keeps a clean separation:

- **`Action(BUY, SELL)`** — the transactional action, attribute of `Transaction`. Common to stocks and crypto.
- **`StockMarketOperation(BUY, SELL, DIVIDEND, SERVICE_FEE, STOCK_SPLIT)`** — classifier for rows in a stock-market CSV. Stock-only; crypto CSVs use `Action` directly because their row type coincides with transaction action.

The silent `.value`-based coercion flagged in `TAX_LAW_AUDIT.md` Issue #1 is replaced by an explicit `StockMarketOperation.to_action()` method that raises for non-transactional values.

## Files touched (14)

- **New**: `pit38/domain/stock/operations/stock_market_operation.py` — enum with `is_transaction()` and `to_action()` helpers
- `pit38/domain/transactions/action.py` — `BUY`/`SELL` only; add `__hash__` (custom `__eq__` requires it for set membership, e.g. `TransactionRowParser.OPERATIONS_HANDLED`)
- `pit38/domain/stock/operations/operation.py` — drop obsolete `OperationType` class; keep thin `Operation` base
- `pit38/domain/stock/operations/{dividend,service_fee,stock_split}.py` — `type = StockMarketOperation.X`
- `pit38/data_sources/stock_loader/factory.py` — key by `StockMarketOperation`; call `.to_action()` explicitly when building `Transaction`
- `pit38/data_sources/stock_loader/csv_loader.py` — parse column into `StockMarketOperation`
- `pit38/plugins/stock/revolut/{row,transaction_row,operation_row}_parser.py` — migrated
- `pit38/stock.py` — `filter_transactions` uses `isinstance(Transaction)`; other `filter_*` methods compare against `StockMarketOperation.X`
- `tests/test_csv_validator.py` — asserts original `"BUY, SELL"` error message (validator wired for crypto stays 2-value)
- `TAX_LAW_AUDIT.md` — Issue #1 marked resolved, with explanation
- `.gitignore` — add `.coverage`, `.coverage.*`, `htmlcov/`

## Why `__hash__`?

`Action.__eq__` is custom (compares `.value`). Python requires `__hash__` when `__eq__` is overridden, or the enum becomes unhashable and can't be used in sets. This matters for e.g. `TransactionRowParser.OPERATIONS_HANDLED = {StockMarketOperation.BUY, StockMarketOperation.SELL}`. Added on both enums to be safe.

## Verification

- [x] `.venv/bin/pytest tests/` → 92 passed
- [x] `pit38 stock -f example_format.csv -y 2025` → same output as main (profit +2 261.13 PLN, tax 429.61 PLN)
- [x] `pit38 crypto -f example_format.csv -y 2025` → same output as main (loss 29 271.00 PLN, tax 0)
- [x] `grep -r OperationType pit38/ tests/` returns only local `BinanceOperationType` (unrelated)
- [x] `grep -rE "Action\.(DIVIDEND|SERVICE_FEE|STOCK_SPLIT)" pit38/ tests/` returns nothing — the semantic boundary holds
- [x] Sanity: `Action.STOCK_SPLIT` raises `AttributeError` — `Transaction.action` cannot be assigned a non-transactional value

## Related

- Resolves `TAX_LAW_AUDIT.md` Issue #1 via two-enum split + explicit conversion
- Unblocks #9 (#56, #57, #58) — `BaseCsvLoader` ABC can now be generic over either enum, and per-loader validators receive the correct subset naturally