### PR TITLE
fix: replace domain asserts with raise ValueError (#63)

### DIFF
--- a/pit38/domain/stock/profit/per_stock_calculator.py
+++ b/pit38/domain/stock/profit/per_stock_calculator.py
@@ -41,9 +41,8 @@ class PerStockProfitCalculator:
         return profit
 
     def _get_company_name(self, transaction: List[Transaction]) -> str:
-        # check all transactions are from the same company
-        assert all(t.asset.asset_name == transaction[0].asset.asset_name for t in transaction), \
-            "All transactions should be from the same company"
+        if not all(t.asset.asset_name == transaction[0].asset.asset_name for t in transaction):
+            raise ValueError("All transactions should be from the same company")
         return transaction[0].asset.asset_name
 
     def _calculate_cost_for_sell(self, buy_queue: Queue, transaction: Transaction) -> FiatValue:

--- a/pit38/domain/stock/profit/stock_split_handler.py
+++ b/pit38/domain/stock/profit/stock_split_handler.py
@@ -56,9 +56,9 @@ class StockSplitHandler:
 
     @classmethod
     def _assert_the_same_company(cls, transactions: List[Transaction], stock_splits: List[StockSplit]):
-        assert all(t.asset.asset_name == transactions[0].asset.asset_name for t in transactions), \
-            "All transactions should be from the same company"
-        assert all(split.stock == stock_splits[0].stock for split in stock_splits), \
-            "All stock splits should be for the same stock"
-        assert transactions[0].asset.asset_name == stock_splits[0].stock, \
-            "All operations should be from the same company"
+        if not all(t.asset.asset_name == transactions[0].asset.asset_name for t in transactions):
+            raise ValueError("All transactions should be from the same company")
+        if not all(split.stock == stock_splits[0].stock for split in stock_splits):
+            raise ValueError("All stock splits should be for the same stock")
+        if transactions[0].asset.asset_name != stock_splits[0].stock:
+            raise ValueError("All operations should be from the same company")


### PR DESCRIPTION
assert statements get stripped with python -O, so these invariant checks would silently disappear. replaced all 4 domain asserts (per_stock_calculator + stock_split_handler) with raise ValueError. same messages, same behavior in normal mode, now safe under -O too.

closes #63