### PR TITLE
Fix/assert to valueerror

### DIFF
--- a/pit38/domain/stock/profit/per_stock_calculator.py
+++ b/pit38/domain/stock/profit/per_stock_calculator.py
@@ -42,8 +42,11 @@ class PerStockProfitCalculator:
 
     def _get_company_name(self, transaction: List[Transaction]) -> str:
         # check all transactions are from the same company
-        assert all(t.asset.asset_name == transaction[0].asset.asset_name for t in transaction), \
-            "All transactions should be from the same company"
+        if not all(
+                t.asset.asset_name == transaction[0].asset.asset_name
+                for t in transaction
+        ):
+            raise ValueError("All transactions should be from the same company")
         return transaction[0].asset.asset_name
 
     def _calculate_cost_for_sell(self, buy_queue: Queue, transaction: Transaction) -> FiatValue:

--- a/pit38/domain/stock/profit/per_stock_calculator.py
+++ b/pit38/domain/stock/profit/per_stock_calculator.py
@@ -58,7 +58,7 @@ class PerStockProfitCalculator:
                 oldest_buy = buy_queue.head()
             except IndexError:
                 raise ValueError("No buy transaction to match sell transaction. Try exporting whole history.")
-            oldest_buy_stock_amount = oldest_buy.asset.amount
+            oldest_buy_stock_amount = oldest_buyasset.amount
 
             if oldest_buy_stock_amount <= stock_amount_to_account + self.EPSILON:
                 cost += self.exchanger.exchange(oldest_buy.date, oldest_buy.fiat_value)

--- a/pit38/domain/stock/profit/per_stock_calculator.py
+++ b/pit38/domain/stock/profit/per_stock_calculator.py
@@ -58,7 +58,7 @@ class PerStockProfitCalculator:
                 oldest_buy = buy_queue.head()
             except IndexError:
                 raise ValueError("No buy transaction to match sell transaction. Try exporting whole history.")
-            oldest_buy_stock_amount = oldest_buyasset.amount
+            oldest_buy_stock_amount = oldest_buy.asset.amount
 
             if oldest_buy_stock_amount <= stock_amount_to_account + self.EPSILON:
                 cost += self.exchanger.exchange(oldest_buy.date, oldest_buy.fiat_value)

--- a/pit38/domain/stock/profit/stock_split_handler.py
+++ b/pit38/domain/stock/profit/stock_split_handler.py
@@ -56,9 +56,19 @@ class StockSplitHandler:
 
     @classmethod
     def _assert_the_same_company(cls, transactions: List[Transaction], stock_splits: List[StockSplit]):
-        assert all(t.asset.asset_name == transactions[0].asset.asset_name for t in transactions), \
-            "All transactions should be from the same company"
-        assert all(split.stock == stock_splits[0].stock for split in stock_splits), \
-            "All stock splits should be for the same stock"
-        assert transactions[0].asset.asset_name == stock_splits[0].stock, \
-            "All operations should be from the same company"
+        if not all(
+                t.asset.asset_name == transactions[0].asset.asset_name
+                for t in transactions
+        ):
+            raise ValueError("All transactions should be from the same company")
+
+        if not all(
+                split.stock == stock_splits[0].stock
+                for split in stock_splits
+        ):
+            raise ValueError("All stock splits should be for the same stock")
+
+        if not (
+                transactions[0].asset.asset_name == stock_splits[0].stock
+        ):
+            raise ValueError("All operations should be from the same company")

--- a/pit38/domain/stock/profit/stock_split_handler.py
+++ b/pit38/domain/stock/profit/stock_split_handler.py
@@ -59,7 +59,7 @@ class StockSplitHandler:
 
         if not all(
                 t.asset.asset_name == transactions[0].asset.asset_name
-                for t transactions
+                for t in transactions
         ):
             raise ValueError("All transactions should be from the same company")
 

--- a/pit38/domain/stock/profit/stock_split_handler.py
+++ b/pit38/domain/stock/profit/stock_split_handler.py
@@ -56,9 +56,10 @@ class StockSplitHandler:
 
     @classmethod
     def _assert_the_same_company(cls, transactions: List[Transaction], stock_splits: List[StockSplit]):
+
         if not all(
                 t.asset.asset_name == transactions[0].asset.asset_name
-                for t in transactions
+                for t transactions
         ):
             raise ValueError("All transactions should be from the same company")
 


### PR DESCRIPTION
Replaces assert statements in domain logic with ValueError to ensure correctness under Python -O mode.

- Prevents silent failure when Python is run with optimizations
- Maintains identical behavior in normal execution
- All 92 tests pass locally


closes #63 