### PR TITLE
refactor: domain cleanups -- exception types + year property

### DIFF
--- a/pit38/domain/crypto/profit_calculator.py
+++ b/pit38/domain/crypto/profit_calculator.py
@@ -28,6 +28,6 @@ class YearlyProfitCalculator:
                 continue
             transaction_value_in_base_currency = self.exchanger.exchange(
                 transaction.date, transaction.fiat_value)
-            transactions_sum_per_year[transaction.year()] += transaction_value_in_base_currency
+            transactions_sum_per_year[transaction.year] += transaction_value_in_base_currency
 
         return transactions_sum_per_year

--- a/pit38/domain/stock/profit/per_stock_calculator.py
+++ b/pit38/domain/stock/profit/per_stock_calculator.py
@@ -35,8 +35,8 @@ class PerStockProfitCalculator:
                 f"Calculated cost and income for transaction: {transaction}, "
                 f"cost = {transaction_cost}, income = {transaction_income}, profit = {transaction_profit}")
 
-            profit.add_income(transaction.year(), transaction_income)
-            profit.add_cost(transaction.year(), transaction_cost)
+            profit.add_income(transaction.year, transaction_income)
+            profit.add_cost(transaction.year, transaction_cost)
 
         return profit
 

--- a/pit38/domain/transactions/asset.py
+++ b/pit38/domain/transactions/asset.py
@@ -14,12 +14,12 @@ class AssetValue:
         if isinstance(other, int) or isinstance(other, float):
             new_amount = self.amount * other
             return AssetValue(new_amount, self.asset_name)
-        raise Exception("Cannot multiply by non-numeric value")
+        raise TypeError("Cannot multiply by non-numeric value")
 
     def __sub__(self, other):
         if isinstance(other, AssetValue):
             if other.asset_name != self.asset_name:
-                raise Exception("Cannot subtract different assets")
+                raise ValueError("Cannot subtract different assets")
             new_amount = self.amount - other.amount
             return AssetValue(new_amount, self.asset_name)
-        raise Exception("Cannot subtract non-asset value")
+        raise TypeError("Cannot subtract non-asset value")

--- a/pit38/domain/transactions/transaction.py
+++ b/pit38/domain/transactions/transaction.py
@@ -16,6 +16,7 @@ class Transaction:
         self.action = action
         self.date = date
 
+    @property
     def year(self) -> int:
         return self.date.year
 
@@ -39,4 +40,4 @@ class Transaction:
                 self.action,
                 self.date,
             )
-        raise Exception("Cannot multiply by non-numeric value")
+        raise TypeError("Cannot multiply by non-numeric value")

--- a/tests/test_asset_value.py
+++ b/tests/test_asset_value.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+
+from pit38.domain.transactions.asset import AssetValue
+
+
+class TestAssetValue(TestCase):
+    def test_mul_by_non_numeric(self):
+        asset = AssetValue(10, "AAPL")
+        with self.assertRaises(TypeError):
+            asset * "abc"
+
+    def test_sub_different_assets(self):
+        a = AssetValue(10, "AAPL")
+        b = AssetValue(5, "GOOGL")
+        with self.assertRaises(ValueError):
+            a - b
+
+    def test_sub_non_asset(self):
+        asset = AssetValue(10, "AAPL")
+        with self.assertRaises(TypeError):
+            asset - 5

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,0 +1,15 @@
+from unittest import TestCase
+
+from pit38.domain.transactions.transaction import Transaction
+from tests.utils import apple, usd, buy
+
+
+class TestTransaction(TestCase):
+    def test_year_property(self):
+        t = buy(apple(1), usd(100), "2023-06-15 12:00")
+        self.assertEqual(t.year, 2023)
+
+    def test_mul_by_non_numeric(self):
+        t = buy(apple(1), usd(100), "2023-01-01 12:00")
+        with self.assertRaises(TypeError):
+            t * "abc"


### PR DESCRIPTION
covers the Style items from #66:

- bare `Exception` -> `TypeError`/`ValueError` in asset.py and transaction.py (4 spots total)
- `Transaction.year()` -> `@property year`, call sites updated
- added tests for the new exception types and the property

all 97 tests pass locally

ref #66