### PR TITLE
refactor: rename CurrencyBuilder to parse_currency()

### DIFF
--- a/pit38/data_sources/crypto_loader/csv_loader.py
+++ b/pit38/data_sources/crypto_loader/csv_loader.py
@@ -4,7 +4,7 @@ import pendulum
 from loguru import logger
 
 from pit38.domain.transactions import Transaction, AssetValue, Action
-from pit38.domain.currency_exchange_service.currencies import CurrencyBuilder, FiatValue, Currency, InvalidCurrencyException
+from pit38.domain.currency_exchange_service.currencies import parse_currency, FiatValue, Currency, InvalidCurrencyException
 
 class Loader:
     @classmethod
@@ -52,7 +52,7 @@ class Loader:
     def _fiat_value(cls, row: dict) -> FiatValue:
         try:
             amount = float(row["fiat_value"])
-            currency = CurrencyBuilder.build(row["currency"])
+            currency = parse_currency(row["currency"])
             return FiatValue(amount, currency)
         except (ValueError, KeyError) as e:
             raise ValueError(f"Failed to parse fiat value: {str(e)}")

--- a/pit38/data_sources/stock_loader/csv_loader.py
+++ b/pit38/data_sources/stock_loader/csv_loader.py
@@ -5,7 +5,7 @@ from loguru import logger
 
 from pit38.domain.stock.operations.operation import Operation, OperationType
 from pit38.data_sources.stock_loader.factory import OperationFactory
-from pit38.domain.currency_exchange_service.currencies import CurrencyBuilder, FiatValue, InvalidCurrencyException
+from pit38.domain.currency_exchange_service.currencies import parse_currency, FiatValue, InvalidCurrencyException
 from pit38.domain.transactions.asset import AssetValue
 from pit38.domain.transactions.transaction import Transaction
 
@@ -66,7 +66,7 @@ class Loader:
             if not row.get("fiat_value"):
                 return None
             amount = float(row["fiat_value"])
-            currency = CurrencyBuilder.build(row["currency"])
+            currency = parse_currency(row["currency"])
             return FiatValue(amount, currency)
         except (ValueError, KeyError) as e:
             raise ValueError(f"Failed to parse fiat value: {str(e)}")

--- a/pit38/domain/currency_exchange_service/currencies.py
+++ b/pit38/domain/currency_exchange_service/currencies.py
@@ -14,21 +14,19 @@ class Currency(enum.Enum):
         return self.value
 
 
-class CurrencyBuilder:
-    # todo: rewrite - it's not a builder, but simple factory
-    CURRENCIES = {
-        "USD": Currency.DOLLAR,
-        "$": Currency.DOLLAR,
-        "EUR": Currency.EURO,
-        "€": Currency.EURO,
-        "PLN": Currency.ZLOTY,
-    }
+CURRENCY_MAP = {
+    "USD": Currency.DOLLAR,
+    "$": Currency.DOLLAR,
+    "EUR": Currency.EURO,
+    "€": Currency.EURO,
+    "PLN": Currency.ZLOTY,
+}
 
-    @staticmethod
-    def build(currency: str) -> Currency:
-        if currency in CurrencyBuilder.CURRENCIES:
-            return CurrencyBuilder.CURRENCIES[currency]
-        raise InvalidCurrencyException(f"Invalid currency: {currency}")
+
+def parse_currency(currency: str) -> Currency:
+    if currency in CURRENCY_MAP:
+        return CURRENCY_MAP[currency]
+    raise InvalidCurrencyException(f"Invalid currency: {currency}")
 
 
 class FiatValue:

--- a/pit38/plugins/crypto/binance/csv.py
+++ b/pit38/plugins/crypto/binance/csv.py
@@ -5,7 +5,7 @@ from typing import List
 
 import pendulum
 from loguru import logger
-from pit38.domain.currency_exchange_service.currencies import CurrencyBuilder, FiatValue
+from pit38.domain.currency_exchange_service.currencies import CURRENCY_MAP, FiatValue
 from pit38.domain.transactions.action import Action
 from pit38.domain.transactions.asset import AssetValue
 from pit38.domain.transactions.transaction import Transaction
@@ -37,7 +37,7 @@ class BinanceTransaction:
 
 class BinanceTransactionProcessor:
     def _process_convert_transactions(self, binance_transactions: List[BinanceTransaction]) -> List[Transaction]:
-        fiat_currencies_list = CurrencyBuilder.CURRENCIES.keys()
+        fiat_currencies_list = CURRENCY_MAP.keys()
         return [
             Transaction(
                 asset=AssetValue(abs(crypto_tx.change), crypto_tx.coin),

--- a/pit38/plugins/crypto/revolut/row_parser.py
+++ b/pit38/plugins/crypto/revolut/row_parser.py
@@ -3,7 +3,7 @@ from typing import Dict
 import pendulum
 from loguru import logger
 
-from pit38.domain.currency_exchange_service.currencies import Currency, CurrencyBuilder, FiatValue
+from pit38.domain.currency_exchange_service.currencies import Currency, parse_currency, FiatValue
 from pit38.domain.transactions.action import Action
 from pit38.domain.transactions.asset import AssetValue
 from pit38.domain.transactions.transaction import Transaction
@@ -48,7 +48,7 @@ class RowParser:
         currency_str = value.replace(amount_str, "").strip()
 
         amount = float(amount_match.group())
-        currency = CurrencyBuilder.build(currency_str)
+        currency = parse_currency(currency_str)
         return FiatValue(amount, currency)
 
     @classmethod

--- a/pit38/plugins/stock/revolut/row_parser.py
+++ b/pit38/plugins/stock/revolut/row_parser.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 import pendulum
 
-from pit38.domain.currency_exchange_service.currencies import Currency, FiatValue, CurrencyBuilder
+from pit38.domain.currency_exchange_service.currencies import Currency, FiatValue, parse_currency
 from pit38.domain.transactions import Transaction
 from pit38.domain.stock.operations.operation import OperationType
 
@@ -32,7 +32,7 @@ class RowParser:
         # "USD 1317.06" or "EUR 500.00" — currency code + space + amount
         code_match = re.match(r'([A-Z]{3})\s+([\d,.]+)', raw)
         if code_match:
-            currency = CurrencyBuilder.build(code_match.group(1))
+            currency = parse_currency(code_match.group(1))
             amount = float(code_match.group(2).replace(",", ""))
             cls._validate_currency(row, currency)
             return FiatValue(amount, currency)
@@ -40,7 +40,7 @@ class RowParser:
         # "$1,003.01" or "€500.00" — currency symbol + amount
         symbol_match = re.match(r'([^\d\s])([\d,.]+)', raw)
         if symbol_match:
-            currency = CurrencyBuilder.build(symbol_match.group(1))
+            currency = parse_currency(symbol_match.group(1))
             amount = float(symbol_match.group(2).replace(",", ""))
             cls._validate_currency(row, currency)
             return FiatValue(amount, currency)
@@ -50,7 +50,7 @@ class RowParser:
     @classmethod
     def _validate_currency(cls, row: Dict, parsed_currency: Currency) -> None:
         if 'Currency' in row and row['Currency']:
-            expected = CurrencyBuilder.build(row['Currency'])
+            expected = parse_currency(row['Currency'])
             if expected != parsed_currency:
                 raise ValueError(
                     f"Currency mismatch: Total Amount implies {parsed_currency}, "


### PR DESCRIPTION
replaces the CurrencyBuilder class with a plain parse_currency() function and a module-level CURRENCY_MAP dict -- the existing todo comment said it's not really a builder anyway.

all 8 call sites updated, 97 tests pass.

ref #66