### PR TITLE
docs: Link GitHub Discussions from README + document category layout (#48)

### DIFF
--- a/.github/DISCUSSIONS.md
+++ b/.github/DISCUSSIONS.md
@@ -1,0 +1,41 @@
+# GitHub Discussions setup
+
+This document captures the category layout and seed threads created for
+pit-38 Discussions. Future maintainers can use it to reconstitute the
+space if needed, or to understand the rationale behind the category split.
+
+## Categories
+
+| Category | Format | Purpose |
+|----------|--------|---------|
+| **Announcements** 📣 | Announcement (maintainer-only) | Release notes, tax-law updates, breaking changes |
+| **Q&A** 🙏 | Question + marked answer | Tax-rule interpretation questions where there's a definite answer |
+| **Broker support** 🏦 | Open-ended | Broker requests, sanitized CSV samples, discussion of quirks |
+
+Other default categories (General, Ideas, Polls, Show and tell) are
+hidden — we want a focused, low-cognitive-load surface. If traffic grows,
+re-enabling them is trivial in Settings → Discussions.
+
+## Seed threads
+
+| # | Category | Title |
+|---|----------|-------|
+| [#72](https://github.com/pbialon/pit-38/discussions/72) | Q&A | How do I handle W-8BEN dividends in PIT-38? |
+| [#73](https://github.com/pbialon/pit-38/discussions/73) | Broker support | Which broker should we support next? |
+| [#74](https://github.com/pbialon/pit-38/discussions/74) | Announcements | Welcome to pit-38 Discussions |
+
+## Posting conventions
+
+- **Language**: Polish and English both welcome. Maintainers respond in
+  the language of the thread. Use `[PL]` prefix in title if Polish-only.
+- **Announcements**: maintainer-only by category configuration.
+- **Broker support**: encourage sanitized CSV snippets (5–10 rows max,
+  PII removed) rather than full exports. See issue #33 for an example
+  of how real exports informed the BOM/locale fixes.
+- **Q&A**: maintainers can mark the accepted answer to boost future
+  searchability — we're using Discussions partly as a knowledge base.
+
+## Links
+
+- [Discussions landing](https://github.com/pbialon/pit-38/discussions)
+- [Closing issue](https://github.com/pbialon/pit-38/issues/48)

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ pytest tests/
 
 This tool is provided for **informational purposes only** and does not constitute tax advice. Always verify your calculations with a qualified tax advisor before filing your PIT-38 declaration.
 
+## Community
+
+- **[GitHub Discussions](https://github.com/pbialon/pit-38/discussions)** — tax-rule Q&A, broker requests, feedback. English and Polish both welcome.
+- **[Issue tracker](https://github.com/pbialon/pit-38/issues)** — bug reports and feature requests.
+
 ---
 
 <a href="https://www.buymeacoffee.com/pbialon" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>

--- a/README.pl.md
+++ b/README.pl.md
@@ -97,6 +97,11 @@ pytest tests/
 
 To narzędzie służy wyłącznie **celom informacyjnym** i nie stanowi porady podatkowej. Przed złożeniem deklaracji PIT-38 zweryfikuj obliczenia z doradcą podatkowym.
 
+## Społeczność
+
+- **[GitHub Discussions](https://github.com/pbialon/pit-38/discussions)** — pytania o zasady podatkowe, prośby o wsparcie nowych brokerów, feedback. Po polsku i angielsku.
+- **[Issue tracker](https://github.com/pbialon/pit-38/issues)** — zgłoszenia błędów i propozycje funkcji.
+
 ---
 
 <a href="https://www.buymeacoffee.com/pbialon" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>


### PR DESCRIPTION
Closes #48. Final step of the Community-ready milestone item.

## Changes

- **README.md / README.pl.md**: add a "Community" section in the footer, linking to Discussions and Issues with a one-line explanation of what goes where. Bilingual mirror as is the convention in this repo.
- **`.github/DISCUSSIONS.md`** (new): documents the category layout (Announcements, Q&A, Broker support), the intentional choice to hide default GH categories (Ideas/Polls/etc.) to keep the surface focused, and the posting conventions (language, PII handling, broker CSV snippets).

## What was already done in #48

The three seed threads are live:
- [#72 Q&A — How do I handle W-8BEN dividends](https://github.com/pbialon/pit-38/discussions/72)
- [#73 Broker support — Which broker should we support next?](https://github.com/pbialon/pit-38/discussions/73)
- [#74 Announcements — Welcome to pit-38 Discussions](https://github.com/pbialon/pit-38/discussions/74)

Discussions were enabled via repo Settings. Custom `Broker support` category was added through the UI (GitHub doesn't expose category creation via API).

## Acceptance criteria (from #48)

- [x] Discussions enabled in `Settings → General → Features`
- [x] Four categories created (Announcements, Q&A, Broker support, + kept default General hidden)
- [x] 3-4 seed threads posted to prime the space
- [x] Discussions linked from `README.md` footer
- [ ] Link from `CONTRIBUTING.md` — will be added in #46 when that file is created (Community-ready milestone)

## Related

- Part of Community-ready milestone (due 2026-04-28)
- Unblocks #47 (issue templates reference Discussions in contact links)
- Unblocks #46 (CONTRIBUTING.md can link to Discussions)