### PR TITLE
bump version to 2026.4.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pit-38"
-version = "2026.4.20.4"
+version = "2026.4.25"
 description = "Polish investment tax calculator (PIT-38) for stocks and cryptocurrency"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release commit for 2026.4.25 — includes IBI Capital plugin, CONTRIBUTING/CoC, issue & PR templates, GitHub Discussions link, pdfplumber dep.

Full release notes go on the GitHub release once this merges.