### PR TITLE
refactor: make FiatValue currency explicit

### DIFF
--- a/pit38/domain/crypto/profit_calculator.py
+++ b/pit38/domain/crypto/profit_calculator.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import List
 from loguru import logger
 
-from pit38.domain.currency_exchange_service.currencies import FiatValue
+from pit38.domain.currency_exchange_service.currencies import Currency, FiatValue
 from pit38.domain.currency_exchange_service.exchanger import Exchanger
 from pit38.domain.tax_service.profit_per_year import ProfitPerYear
 from pit38.domain.transactions import Transaction, Action
@@ -22,7 +22,7 @@ class YearlyProfitCalculator:
 
     def _sum_transactions_per_year(self, transactions: List[Transaction], transaction_type: Action) \
             -> defaultdict[int, FiatValue]:
-        transactions_sum_per_year: defaultdict[int, FiatValue] = defaultdict(lambda: FiatValue(0))
+        transactions_sum_per_year: defaultdict[int, FiatValue] = defaultdict(lambda: FiatValue.zero(Currency.ZLOTY))
         for transaction in transactions:
             if transaction.action != transaction_type:
                 continue

--- a/pit38/domain/currency_exchange_service/currencies.py
+++ b/pit38/domain/currency_exchange_service/currencies.py
@@ -30,9 +30,13 @@ def parse_currency(currency: str) -> Currency:
 
 
 class FiatValue:
-    def __init__(self, amount: float = 0, currency: Currency = Currency.ZLOTY):
+    def __init__(self, amount: float, currency: Currency):
         self.amount = amount
         self.currency = currency
+
+    @classmethod
+    def zero(cls, currency: Currency):
+        return cls(0, currency)
 
     def __add__(self, other):
         if self.currency != other.currency:

--- a/pit38/domain/stock/profit/per_stock_calculator.py
+++ b/pit38/domain/stock/profit/per_stock_calculator.py
@@ -2,7 +2,7 @@ from typing import List
 
 from loguru import logger
 
-from pit38.domain.currency_exchange_service.currencies import FiatValue
+from pit38.domain.currency_exchange_service.currencies import Currency, FiatValue
 from pit38.domain.currency_exchange_service.exchanger import Exchanger
 from pit38.domain.tax_service.profit_per_year import ProfitPerYear
 from pit38.domain.stock.queue import Queue
@@ -51,7 +51,7 @@ class PerStockProfitCalculator:
 
     def _calculate_cost_for_sell(self, buy_queue: Queue, transaction: Transaction) -> FiatValue:
         stock_amount_to_account = transaction.asset.amount
-        cost = FiatValue(0)
+        cost = FiatValue.zero(Currency.ZLOTY)
 
         while stock_amount_to_account > self.EPSILON:
             try:

--- a/pit38/domain/tax_service/crypto_tax_calculator.py
+++ b/pit38/domain/tax_service/crypto_tax_calculator.py
@@ -1,4 +1,4 @@
-from pit38.domain.currency_exchange_service.currencies import FiatValue
+from pit38.domain.currency_exchange_service.currencies import Currency, FiatValue
 from pit38.domain.tax_service.profit_per_year import ProfitPerYear
 from pit38.domain.tax_service.tax_year_result import TaxYearResult
 
@@ -17,12 +17,12 @@ class CryptoTaxCalculator:
         deductible_loss: float = -1,
     ) -> TaxYearResult:
         if deductible_loss != -1:
-            loss = FiatValue(deductible_loss)
+            loss = FiatValue(deductible_loss, Currency.ZLOTY)
         else:
             loss = self._deductible_loss(profit_per_year, tax_year)
 
         profit_in_tax_year = profit_per_year.get_profit(tax_year)
-        if loss > FiatValue(0):
+        if loss > FiatValue.zero(Currency.ZLOTY):
             profit_in_tax_year = profit_in_tax_year - loss
 
         return TaxYearResult(
@@ -37,15 +37,15 @@ class CryptoTaxCalculator:
     def _deductible_loss(
         self, profit_per_year: ProfitPerYear, tax_year: int
     ) -> FiatValue:
-        accumulated_loss = FiatValue(0)
+        accumulated_loss = FiatValue.zero(Currency.ZLOTY)
         for year in sorted(y for y in profit_per_year.all_years() if y < tax_year):
             profit_this_year = profit_per_year.get_profit(year)
             if profit_this_year >= accumulated_loss:
-                accumulated_loss = FiatValue(0)
+                accumulated_loss = FiatValue.zero(Currency.ZLOTY)
                 continue
             accumulated_loss = accumulated_loss - profit_this_year
         return accumulated_loss
 
     def _calculate_tax(self, profit: FiatValue) -> FiatValue:
-        zero = FiatValue(0)
+        zero = FiatValue.zero(Currency.ZLOTY)
         return profit * self.tax_rate if profit > zero else zero

--- a/pit38/domain/tax_service/loss_deduction.py
+++ b/pit38/domain/tax_service/loss_deduction.py
@@ -1,18 +1,18 @@
 from dataclasses import dataclass, field
 from typing import List
 
-from pit38.domain.currency_exchange_service.currencies import FiatValue
+from pit38.domain.currency_exchange_service.currencies import Currency, FiatValue
 from pit38.domain.tax_service.profit_per_year import ProfitPerYear
 
-FIVE_MILLION = FiatValue(5_000_000)
-ZERO = FiatValue(0)
+FIVE_MILLION = FiatValue(5_000_000, Currency.ZLOTY)
+ZERO = FiatValue.zero(Currency.ZLOTY)
 
 
 @dataclass
 class LossRecord:
     year: int
     original_amount: FiatValue
-    already_deducted: FiatValue = field(default_factory=FiatValue)
+    already_deducted: FiatValue = field(default_factory=lambda: FiatValue.zero(Currency.ZLOTY))
 
     @property
     def remaining(self) -> FiatValue:
@@ -44,7 +44,7 @@ class StockLossDeductionStrategy:
         if profit <= ZERO:
             return ZERO
 
-        total_deducted = FiatValue(0)
+        total_deducted = FiatValue.zero(Currency.ZLOTY)
         remaining_profit = profit
 
         for loss in losses:

--- a/pit38/domain/tax_service/profit_per_year.py
+++ b/pit38/domain/tax_service/profit_per_year.py
@@ -1,12 +1,12 @@
 from collections import defaultdict
 
-from pit38.domain.currency_exchange_service.currencies import FiatValue
+from pit38.domain.currency_exchange_service.currencies import Currency, FiatValue
 
 
 class ProfitPerYear:
     def __init__(self, income: defaultdict[int, FiatValue] = None, cost: defaultdict[int, FiatValue] = None):
-        self.income = income if income is not None else defaultdict(FiatValue)
-        self.cost = cost if cost is not None else defaultdict(FiatValue)
+        self.income = income if income is not None else defaultdict(lambda: FiatValue.zero(Currency.ZLOTY))
+        self.cost = cost if cost is not None else defaultdict(lambda: FiatValue.zero(Currency.ZLOTY))
 
     def add_income(self, year: int, value: FiatValue):
         self.income[year] += value

--- a/pit38/domain/tax_service/stock_tax_calculator.py
+++ b/pit38/domain/tax_service/stock_tax_calculator.py
@@ -1,4 +1,4 @@
-from pit38.domain.currency_exchange_service.currencies import FiatValue
+from pit38.domain.currency_exchange_service.currencies import Currency, FiatValue
 from pit38.domain.tax_service.loss_deduction import StockLossDeductionStrategy
 from pit38.domain.tax_service.profit_per_year import ProfitPerYear
 from pit38.domain.tax_service.tax_year_result import TaxYearResult
@@ -16,14 +16,14 @@ class StockTaxCalculator:
         deductible_loss: float = -1,
     ) -> TaxYearResult:
         if deductible_loss != -1:
-            loss = FiatValue(deductible_loss)
+            loss = FiatValue(deductible_loss, Currency.ZLOTY)
         else:
             loss = self._loss_strategy.calculate_deductible_loss(
                 profit_per_year, tax_year
             )
 
         profit_in_tax_year = profit_per_year.get_profit(tax_year)
-        if loss > FiatValue(0):
+        if loss > FiatValue.zero(Currency.ZLOTY):
             profit_in_tax_year = profit_in_tax_year - loss
 
         return TaxYearResult(
@@ -36,5 +36,5 @@ class StockTaxCalculator:
         )
 
     def _calculate_tax(self, profit: FiatValue) -> FiatValue:
-        zero = FiatValue(0)
+        zero = FiatValue.zero(Currency.ZLOTY)
         return profit * self.tax_rate if profit > zero else zero

--- a/tests/test_currencies.py
+++ b/tests/test_currencies.py
@@ -29,6 +29,9 @@ class TestFiatValue(TestCase):
         with self.assertRaises(ValueError):
             a * "a"
 
+    def test_zero(self):
+        self.assertEqual(FiatValue.zero(Currency.DOLLAR), FiatValue(0, Currency.DOLLAR))
+
     def test_gt(self):
         a = usd(100)
         b = usd(200)


### PR DESCRIPTION
covers the FiatValue constructor cleanup from #66:

- adds `FiatValue.zero(currency)` for explicit zero values
- removes default amount/currency from `FiatValue.__init__`
- updates PLN accumulators to use explicit `Currency.ZLOTY`

all 190 tests pass locally

ref #66